### PR TITLE
Fixed decoding of features with null geometry

### DIFF
--- a/Sources/GeoJSON/Feature.swift
+++ b/Sources/GeoJSON/Feature.swift
@@ -36,7 +36,7 @@ public struct Feature: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        geometry = try container.decode(Geometry.self, forKey: .geometry)
+        geometry = try container.decodeIfPresent(Geometry.self, forKey: .geometry)
         if let id = try? container.decodeIfPresent(String.self, forKey: .id) {
             self.id = id
         } else if let id = try container.decodeIfPresent(Double.self, forKey: .id) {

--- a/Tests/GeoJSONTests/DecodingTests.swift
+++ b/Tests/GeoJSONTests/DecodingTests.swift
@@ -22,6 +22,19 @@ final class DecodingTests: XCTestCase {
         let illegalBbox = "[10.0, 10.0, 10.0]".data(using: .utf8)!
         XCTAssertThrowsError(try JSONDecoder().decode(BoundingBox.self, from: illegalBbox))
     }
+    
+    func testDencodeEmptyFeature() throws {
+        let json = """
+        {
+          "geometry" : null,
+          "properties" : null,
+          "type" : "Feature"
+        }
+        """.data(using: .utf8)!
+        
+        let feature = try JSONDecoder().decode(Feature.self, from: json)
+        XCTAssertEqual(feature, .init(geometry: nil))
+    }
 
     func testDecodeHomepageExample() throws {
         let json = """


### PR DESCRIPTION
First, thank you for this repository! There are a bunch of Swift GeoJSON packages available, but I find this one to be the easiest to use and most complete. Kudos!

This PR fixes an issue where a `Feature` could not be decoded if its `geometry` was `null`. During encoding, there was no problem because `Feature`'s `geometry` property is optional, and `Feature.encode(to:)` handles a `nil` value as expected. I only made a very small change to `Feature.init(from:)` to allow reading an optional rather than required `geometry` value, and added a test case in `DecodingTests`.