### PR TITLE
Allow decoding positions with > 3 elements

### DIFF
--- a/Sources/GeoJSON/Geometry/Position.swift
+++ b/Sources/GeoJSON/Geometry/Position.swift
@@ -21,7 +21,7 @@ public struct Position: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        guard container.count == 2 || container.count == 3 else {
+        guard (container.count ?? 0) >= 2 else {
             throw Error.unexpectedValueCount
         }
         self.longitude = try container.decode(Double.self)

--- a/Tests/GeoJSONTests/DecodingTests.swift
+++ b/Tests/GeoJSONTests/DecodingTests.swift
@@ -29,7 +29,7 @@ final class DecodingTests: XCTestCase {
           "type": "Feature",
           "geometry": {
             "type": "Point",
-            "coordinates": [125.6, 10.1]
+            "coordinates": [125.6, 10.1, 0, 0]
           },
           "properties": {
             "name": "Dinagat Islands"
@@ -38,7 +38,7 @@ final class DecodingTests: XCTestCase {
         """.data(using: .utf8)!
 
         let feature = try JSONDecoder().decode(Feature.self, from: json)
-        XCTAssertEqual(feature.geometry, .point(Point(longitude: 125.6, latitude: 10.1)))
+        XCTAssertEqual(feature.geometry, .point(Point(longitude: 125.6, latitude: 10.1, altitude: 0.0)))
         XCTAssertEqual(feature.properties?["name"], "Dinagat Islands")
         XCTAssertEqual(feature.properties?.name, "Dinagat Islands")
 


### PR DESCRIPTION
Since some implementations of GeoJSON positions include a fourth number in their array, the requirement in `Position.init(from:)` for exactly 2 or 3 elements caused errors when trying to read files that include the fourth element. I made a change to allow reading `Position`s with any number of elements as long as there are at least 2 (all past the elevation are ignored).

For reference, in [RFC 7946 3.1.1](https://www.rfc-editor.org/rfc/rfc7946#section-3.1.1):

> Implementations SHOULD NOT extend positions beyond three elements
   because the semantics of extra elements are unspecified and
   ambiguous.  Historically, some implementations have used a fourth
   element to carry a linear referencing measure (sometimes denoted as
   "M") or a numerical timestamp, but in most situations a parser will
   not be able to properly interpret these values.  The interpretation
   and meaning of additional elements is beyond the scope of this
   specification, and additional elements MAY be ignored by parsers.

I take the "additional elements MAY be ignored by parsers" to mean it's okay to read an element with the fourth number and just ignore it without throwing an error.

Encoding `Position`s to JSON is unchanged.